### PR TITLE
Support for regulating volume of background music

### DIFF
--- a/VoltAir/Engine/Engine.cpp
+++ b/VoltAir/Engine/Engine.cpp
@@ -224,7 +224,7 @@ void Engine::onLoadCompleted(bool success) {
 
         // If this is a timed level, set up timers and start them rolling.
         mSoundManager->setBGMTrack(SoundManager::EnvironmentalPriority,
-                Util::getPathToSound(mInFlightLevelInfo->getEnvironment()->getBGMTrack()));
+                Util::getPathToSound(mInFlightLevelInfo->getEnvironment()->getBGMTrack()), SoundManager::LevelVolume);
 
         // Mark level load complete.
         mLevelReady = true;
@@ -476,6 +476,6 @@ void Engine::onQuitRequested() {
 }
 
 void Engine::onOpeningCinematicCompleted(const QString& menuBGMTrack) {
-    mSoundManager->setBGMTrack(SoundManager::MenuPriority, Util::getPathToSound(menuBGMTrack));
+    mSoundManager->setBGMTrack(SoundManager::MenuPriority, Util::getPathToSound(menuBGMTrack), SoundManager::MenuVolume);
     mSoundManager->setPaused(false);
 }

--- a/VoltAir/Engine/android/AndroidActivity.cpp
+++ b/VoltAir/Engine/android/AndroidActivity.cpp
@@ -334,7 +334,7 @@ void AndroidActivity::clearBGMTrack(int priority) {
     jni->DeleteLocalRef(soundManager);
 }
 
-void AndroidActivity::setBGMTrack(int priority, const QString &track) {
+void AndroidActivity::setBGMTrack(int priority, const QString &track, int volume) {
     auto jni = getEnv();
     if (!jni || !getActivity()) {
         return;
@@ -342,10 +342,10 @@ void AndroidActivity::setBGMTrack(int priority, const QString &track) {
     jobject soundManager = getSoundManager();
     jclass soundManagerClass = getSoundManagerClass(jni.getJNIEnv(), soundManager);
     jmethodID setBGMTrackMethod = jni->GetMethodID(soundManagerClass, "setBGMTrack",
-            "(ILjava/lang/String;)V");
+            "(ILjava/lang/String;I)V");
     std::string nativeTrack = track.toStdString();
     jstring javaTrack = jni->NewStringUTF(nativeTrack.c_str());
-    jni->CallVoidMethod(soundManager, setBGMTrackMethod, priority, javaTrack);
+    jni->CallVoidMethod(soundManager, setBGMTrackMethod, priority, javaTrack, volume);
     jni->DeleteLocalRef(javaTrack);
     jni->DeleteLocalRef(soundManager);
 }

--- a/VoltAir/Engine/android/AndroidActivity.h
+++ b/VoltAir/Engine/android/AndroidActivity.h
@@ -205,8 +205,9 @@ public:
      * @note See SoundManager::setBGMTrack for more details.
      * @param priority Priority level of BGM to set
      * @param track Name of track to use for BGM
+     * @param volume Volume level of BGM to set
      */
-    static void setBGMTrack(int priority, const QString& track);
+    static void setBGMTrack(int priority, const QString& track, int volume);
     /**
      * @brief Returns whether or not the Android SoundManager's background music is muted.
      * @note See SoundManager::isBGMMuted for more details.

--- a/VoltAir/Engine/audio/SoundManager.cpp
+++ b/VoltAir/Engine/audio/SoundManager.cpp
@@ -47,9 +47,9 @@ void SoundManager::clearBGMTrack(BGMPriority priority) {
 #endif
 }
 
-void SoundManager::setBGMTrack(BGMPriority priority, const QString& path) {
+void SoundManager::setBGMTrack(BGMPriority priority, const QString& path, int volumeLevel) {
 #ifdef Q_OS_ANDROID
-    AndroidActivity::setBGMTrack(int(priority), path);
+    AndroidActivity::setBGMTrack(int(priority), path, volumeLevel);
 #else
     if (priority != InvalidPriority) {
         QUrl track = Util::getUrlPathToAsset(path);

--- a/VoltAir/Engine/audio/SoundManager.h
+++ b/VoltAir/Engine/audio/SoundManager.h
@@ -77,6 +77,15 @@ public:
     };
 
     /**
+     * @brief Volume levels for background music tracks.
+     *
+     * This value is used as a divisor of calculated volume value. One is 'max'; 
+     * the higher value -- the quiter sound.
+     */
+    static const int MenuVolume = 1;
+    static const int LevelVolume = 10;
+
+    /**
      * @brief Constructs a SoundManager.
      * @note It is expected that there will only ever exist one instance of SoundManager at a time.
      * @param parent Parent object
@@ -137,8 +146,9 @@ public:
      * @brief Sets the audio track of the specified background priority level.
      * @param priority Background music priority level to set the audio track for
      * @param path Audio track asset path to load for the sound effect
+     * @param volume for background music track
      */
-    Q_INVOKABLE void setBGMTrack(BGMPriority priority, const QString& path);
+    Q_INVOKABLE void setBGMTrack(BGMPriority priority, const QString& path, int volumeLevel);
 
 signals:
     /**


### PR DESCRIPTION
Fix #37

Volume level option is made as an integer that can be used to reduce volume, with 2 levels:
for menu and for game levels (environment). As this volume level is defined on
logic subsystem of the game, it has to be passed down all the way to media player subsystem.

Right now, volume for menu is left as it was, while volume for levels is reduced 10 times.